### PR TITLE
Add token-level recall metric (get_metric_recall_default_prep)

### DIFF
--- a/ovqa/metrics/simple.py
+++ b/ovqa/metrics/simple.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import collections
 from typing import Optional
 
 import numpy as np
 import torch
-from transformers.data.metrics.squad_metrics import compute_f1
+from transformers.data.metrics.squad_metrics import compute_f1, get_tokens
 
 from ovqa.metrics.preprocessing import PrepC, get_preprocessing_fn
 from ovqa.metrics.torchmetrics_ext import MetricExt
@@ -50,6 +51,14 @@ def get_f1_score_default_prep():
     )
 
 
+def get_metric_recall_default_prep():
+    return TextComparison(
+        comparison_fn=compare_recall,
+        preproc_cand=PrepC.SIMPLE,
+        preproc_ref=PrepC.SIMPLE,
+    )
+
+
 def compare_is_equal(cand: str, ref: str):
     if cand == ref:
         return 1.0
@@ -67,6 +76,24 @@ def compare_is_contained(cand: str, ref: str):
 def compare_f1(cand: str, ref: str):
     """Switch argument order to match all other comparison functions and ensure float."""
     return float(compute_f1(ref, cand))
+
+
+def compare_recall(cand: str, ref: str):
+    """Token-level recall of the candidate against the reference.
+
+    Mirrors squad_metrics.compute_f1 but returns only the recall component
+    (fraction of reference tokens that also appear in the candidate).
+    """
+    gold_toks = get_tokens(ref)
+    pred_toks = get_tokens(cand)
+    common = collections.Counter(gold_toks) & collections.Counter(pred_toks)
+    num_same = sum(common.values())
+    if len(gold_toks) == 0:
+        # If the reference is empty, recall is 1.0 iff the candidate is also empty.
+        return float(gold_toks == pred_toks)
+    if num_same == 0:
+        return 0.0
+    return num_same / len(gold_toks)
 
 
 def check_length_of_cand(cand: str, ref: str):


### PR DESCRIPTION
## Add a token-level recall metric

This adds `get_metric_recall_default_prep()` and a `compare_recall` comparison
function to `ovqa/metrics/simple.py`, mirroring the existing
`get_f1_score_default_prep()` / `compare_f1`.

`compare_recall` reuses `transformers`' SQuAD `get_tokens` (already used by
`compute_f1`) and returns the **recall** component of the token overlap — the
fraction of reference tokens that also appear in the candidate — with the same
empty-string edge-case handling as the SQuAD F1.

### Why

Report / VQA evaluations often report recall alongside F1 and accuracy, but OVQA
only exposes F1 and exact/contains comparisons. This is a small, dependency-free
addition consistent with the existing metric factories.

### Notes

- No new dependencies (`collections` is stdlib; `get_tokens` comes from the same
  `transformers.data.metrics.squad_metrics` module already imported for F1).
- No changes to existing behaviour.
